### PR TITLE
Fix validator vtrust

### DIFF
--- a/neurons/indexing.py
+++ b/neurons/indexing.py
@@ -1,6 +1,7 @@
 import redis
 import os
 import dotenv
+
 dotenv.load_dotenv()
 if os.getenv("REDIS_PASSWORD") is None or os.getenv("REDIS_PASSWORD") == "":
     r = redis.Redis(host = os.getenv("REDIS_HOST"), port = os.getenv("REDIS_PORT"), decode_responses = True, db = 0)
@@ -8,13 +9,20 @@ if os.getenv("REDIS_PASSWORD") is None or os.getenv("REDIS_PASSWORD") == "":
 else:
     r = redis.Redis(host = os.getenv("REDIS_HOST"), port = os.getenv("REDIS_PORT"), decode_responses = True, password= os.getenv("REDIS_PASSWORD"), db = 0)
     r1 = redis.Redis(host = os.getenv("REDIS_HOST"), port = os.getenv("REDIS_PORT"), decode_responses = True, password= os.getenv("REDIS_PASSWORD"),  db = 1)
+
+
 def save(key, value):
     r.set(key, value)
+
+
 def get(key):
     return r.get(key)
 
+
 def save_temp_indexing(key, value):
     r1.set(key, value)
+
+
 def get_temp_indexing(key):
     return r1.get(key)
 # Delete db1    

--- a/template/validator/forward.py
+++ b/template/validator/forward.py
@@ -99,7 +99,7 @@ async def forward(self):
                 bt.logging.success(f"Got the latest commit from miner {miner['uid']}")
                 partial = functools.partial(bt.extrinsics.serving.get_metadata, self.subtensor, self.config.netuid, miner['hotkey'])
                 metadata = run_in_subprocess(partial, 30)
-                if self.subtensor.block - metadata['block'] > 200:
+                if self.subtensor.block - metadata['block'] > 300:
                     responses.append({'uid': miner['uid'], 'hotkey': miner['hotkey'], 'commit': None, 'block': None})
                 # print(f"latest_commit: {latest_commit} block: {metadata['block']}")
                 else:

--- a/template/validator/forward.py
+++ b/template/validator/forward.py
@@ -47,9 +47,10 @@ async def forward(self):
 
             try:
                 latest_commit = self.subtensor.get_commitment(netuid = self.config.netuid, uid = miner['uid'])
+                bt.logging.success(f"Got the latest commit from miner {miner['uid']}")
                 partial = functools.partial(bt.extrinsics.serving.get_metadata, self.subtensor, self.config.netuid, miner['hotkey'])
                 metadata = run_in_subprocess(partial, 30)
-                if self.subtensor.block - metadata['block'] > 300:
+                if self.subtensor.block - metadata['block'] > 200:
                     responses.append({'uid': miner['uid'], 'hotkey': miner['hotkey'], 'commit': None, 'block': None})
                 # print(f"latest_commit: {latest_commit} block: {metadata['block']}")
                 else:
@@ -59,7 +60,7 @@ async def forward(self):
                 bt.logging.error(f"failed to get metadata from miner {miner['uid']}")
                 responses.append({'uid': miner['uid'], 'hotkey': miner['hotkey'], 'commit': None, 'block': None})
                 continue
-        print(f"responses: {responses}")
+        bt.logging.success("Got all commits from miners")
         rewards = get_rewards(self, responses=responses)
         self.last_block = self.subtensor.block
         bt.logging.info(f"Scored responses: {rewards}")

--- a/template/validator/reward.py
+++ b/template/validator/reward.py
@@ -40,6 +40,7 @@ def reward(query: int, response: int) -> float:
 
 
 twitter_scraper = twitter_scraper.TwitterScraper("data/", os.getenv("APIFY_KEY"))
+
 def get_rewards(
     self,
     responses
@@ -94,7 +95,6 @@ def get_rewards(
                     if indexing.get(row['id']) is not None:
                         continue
                     if already_indexed is not None:
-                        
                         if int(already_indexed.split("_")[0]) > response['block']:
                             indexing.save_temp_indexing(row['id'], str(response['block']) + "_" + str(response['uid']))
                     else:
@@ -146,4 +146,3 @@ def get_rewards(
     return torch.FloatTensor(
         [counts.get(str(response['uid']), 0) ** 2 for response in responses]  # default value of 0 if key does not exist
     ).to(self.device)
-


### PR DESCRIPTION
Implemented a batching technique in dataset indexing to reduce unnecessary write operations to Redis, enhancing performance by a lot. The indexing will run before scoring the miners. It should take almost no time once the initial dataset ids are indexed the first time.

Validator will sync the redis local to the current dataset, thus giving the correct scores and fixing vtrust issues.